### PR TITLE
Return body on unwanted status codes

### DIFF
--- a/contacts.go
+++ b/contacts.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 )
 
@@ -114,7 +115,12 @@ func (a *ActiveCampaign) ContactCreate(ctx context.Context, contact ContactCreat
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusCreated {
-		return nil, errors.New("contact create: " + res.Status)
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, &Error{Op: "contact create", Err: errors.New("wrong status code"), Body: body}
 	}
 
 	var contactCreated struct {

--- a/error.go
+++ b/error.go
@@ -1,8 +1,9 @@
 package activecampaign
 
 type Error struct {
-	Op  string
-	Err error
+	Op   string
+	Err  error
+	Body []byte
 }
 
 func (e *Error) Unwrap() error { return e.Err }


### PR DESCRIPTION
This pull request includes changes to improve error handling in the `contacts.go` file by adding more detailed error information and updating the `Error` struct in `error.go`.

Improvements to error handling:

* [`contacts.go`](diffhunk://#diff-64435cbb4c989e3f6f3d9bf8c393ec258039dc9e3dc8e20a88e4d71451de2bcdR8): Added the `io` package to the import list to enable reading the response body in case of an error.
* [`contacts.go`](diffhunk://#diff-64435cbb4c989e3f6f3d9bf8c393ec258039dc9e3dc8e20a88e4d71451de2bcdL117-R123): Updated the `ContactCreate` function to read the response body and include it in the error message if the status code is not `http.StatusCreated`. This provides more context for debugging.

Updates to `Error` struct:

* [`error.go`](diffhunk://#diff-097efd4fdcfbc4644e1d6fd6b758f217ca51969e14309c8b70d42a6e41dde579R6): Added a `Body` field to the `Error` struct to store the response body when an error occurs, allowing for more detailed error information.