### PR TITLE
Updated workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,9 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
-    reviewers:
-      - "Fank"
+      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    reviewers:
-      - "Fank"
+      interval: "weekly"

--- a/.github/templates/go-licenses.md.tpl
+++ b/.github/templates/go-licenses.md.tpl
@@ -1,0 +1,5 @@
+## [go-licenses](https://github.com/google/go-licenses) report
+
+{{- range . }}
+- {{ .Name }} ({{ .Version }}) [{{ .LicenseName }}]({{ .LicenseURL }})
+{{- end }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Trigger on version tags like v1.0.0, v2.1.0, etc.
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+
+      - name: Generate Changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v5
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Release ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.changelog }}  # Attach changelog

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   golangci:
-    name: lint
+    name: Go Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -34,11 +34,10 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
 
   test:
     runs-on: ubuntu-latest
+    name: Go Test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -63,31 +62,3 @@ jobs:
         uses: robherley/go-test-action@v0
         with:
           testArguments: ./...
-
-  license-check:
-    runs-on: ubuntu-latest
-    name: License Check
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: ./go.mod
-
-      - name: Install go-licenses
-        run: go install github.com/google/go-licenses@latest
-        shell: bash
-
-      - name: Check licenses
-        run: >
-          go-licenses check ./...
-          --ignore ${{ github.repository }}
-        shell: bash
-
-      - name: Get licenses list
-        run: >
-          go-licenses csv ./...
-          --ignore ${{ github.repository }}
-        shell: bash

--- a/.github/workflows/license_go.yml
+++ b/.github/workflows/license_go.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/license_go.yml
+++ b/.github/workflows/license_go.yml
@@ -1,0 +1,48 @@
+name: License Go
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+    name: License Check
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+
+      - name: Check licenses
+        run: go-licenses check ./...
+
+  license-report:
+    runs-on: ubuntu-latest
+    name: License Report
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+
+      - name: Report to GitHub Step Summary
+        run: >
+          go-licenses report ./...
+          --template .github/templates/go-licenses.md.tpl
+          >> $GITHUB_STEP_SUMMARY
+        shell: bash


### PR DESCRIPTION
This pull request includes several updates to the GitHub workflows, focusing on adding a release workflow, renaming job steps for clarity, and restructuring the license checks.

### New Release Workflow:
* Added a new workflow file `.github/workflows/changelog.yml` to automate GitHub releases, including generating a changelog and creating a release.

### Workflow Job Renaming:
* Renamed the lint job to "Go Lint" and the test job to "Go Test" in `.github/workflows/go.yml` for better clarity. [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL16-R16) [[2]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL37-R40)

### License Check Restructuring:
* Removed the license-check job from `.github/workflows/go.yml` and created a new workflow file `.github/workflows/license_go.yml` dedicated to license checks and reports. [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL66-L93) [[2]](diffhunk://#diff-4086cd651c06d7a18d9940946971a0bff2d4c636298ab9688c723a93cb11417aR1-R49)